### PR TITLE
Include the jupyter-server-proxy license

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -2,5 +2,6 @@
 # Misc
 include requirements.txt
 include LICENSE
+include LICENSE-jupyter-server-proxy
 include README.md
 global-exclude *.py[co]


### PR DESCRIPTION
The Apache license is correctly included in the Python package but the `jupyter-server-proxy` is missing.