### PR TITLE
Redirect percent-encoded prefixes to proxy handler

### DIFF
--- a/jhsingle_native_proxy/main.py
+++ b/jhsingle_native_proxy/main.py
@@ -1,8 +1,9 @@
 from tornado.httpserver import HTTPServer
 from tornado import ioloop
-from tornado.web import Application, RequestHandler
+from tornado.web import Application, RequestHandler, RedirectHandler
 from tornado.log import app_log
 from asyncio import ensure_future
+from urllib.parse import quote
 import click
 import re
 import os
@@ -67,7 +68,12 @@ def make_app(destport, prefix, command, presentation_path, authtype, request_tim
             r"^"+re.escape(prefix)+r"/(.*)",
             proxy_handler,
             dict(state={}, authtype=authtype)
-        )
+        ),
+        (
+            r"^"+re.escape(quote(prefix))+r"/(.*)",
+            RedirectHandler,
+            dict(url=prefix+"/{0}")
+        ),
     ],
     debug=debug,
     cookie_secret=os.urandom(32),


### PR DESCRIPTION
First of all thanks for this project.

We have a use case where JH user names are emails, and so appear as `/user/x@y.com/` in the url. The problem is that some asset fetch requests of the web application we are serving with `jhsingle-native-proxy` are url-encoding the path string so it becomes  `/user/x%40y.com/`. This change redirects such requests to the proxy handler.