### PR TITLE
Support new lines on headers

### DIFF
--- a/jhsingle_native_proxy/proxyhandlers.py
+++ b/jhsingle_native_proxy/proxyhandlers.py
@@ -253,7 +253,7 @@ class ProxyHandler(HubOAuthenticated, WebSocketHandlerMixin):
 
         def dump_headers(headers_raw):
             for line in headers_raw:
-                r = re.match('^([a-zA-Z0-9\-_]+)\s*\:\s*([^\r\n]+)$', line)
+                r = re.match('^([a-zA-Z0-9\-_]+)\s*\:\s*([^\r\n]+)[\r\n]*$', line)
                 if r:
                     k,v = r.groups([1,2])
                     if k not in ('Content-Length', 'Transfer-Encoding',


### PR DESCRIPTION
The headers being passed through the callback actually have a new line character at the end. As such, make sure to support this within the regex match, but not include it in the header value.