### PR TITLE
Add ready timeout parameter

### DIFF
--- a/jhsingle_native_proxy/main.py
+++ b/jhsingle_native_proxy/main.py
@@ -30,7 +30,7 @@ def patch_default_headers():
     RequestHandler.set_default_headers = set_jupyterhub_header
 
 
-def make_app(destport, prefix, command, presentation_path, authtype, request_timeout, ready_check_path, repo, 
+def make_app(destport, prefix, command, presentation_path, authtype, request_timeout, ready_check_path, ready_timeout, repo,
                 repobranch, repofolder, conda_env_name, debug, logs, forward_user_info, query_user_info, progressive):
 
     presentation_basename = ''
@@ -56,7 +56,7 @@ def make_app(destport, prefix, command, presentation_path, authtype, request_tim
         
         command = ['python3', '-m', 'jhsingle_native_proxy.conda_runner', conda_prefix, env_path] + command
 
-    proxy_handler = _make_serverproxy_handler('mainprocess', command, {}, 10, False, destport, ready_check_path, gitwrapper, {})
+    proxy_handler = _make_serverproxy_handler('mainprocess', command, {}, 10, False, destport, ready_check_path, ready_timeout, gitwrapper, {})
 
     return Application([
         (
@@ -137,6 +137,7 @@ def get_ssl_options():
 @click.option('--last-activity-interval', default=300, type=click.INT, help='frequency to notify hub that dashboard is still running in seconds (default 300), 0 for never')
 @click.option('--force-alive/--no-force-alive', default=True, help='Always report that there has been activity (force keep alive) - only happens if last-activity-interval > 0')
 @click.option('--ready-check-path', default='/', help='URL path to poll for readiness (default /)')
+@click.option('--ready-timeout', default=60, help='Timeout for readiness request in seconds (default 60)')
 @click.option('--repo', default='', help="Git repo to pull before running webapp subprocess")
 @click.option('--repobranch', default='master', help="Branch to checkout (if --repo provided)")
 @click.option('--repofolder', default='.', help="Relative folder to hold git repo contents (if --repo provided)")
@@ -148,7 +149,7 @@ def get_ssl_options():
 @click.option('--progressive/--no-progressive', default=False, help='Progressively flush responses as they arrive (good for Voila)')
 @click.argument('command', nargs=-1, required=True)
 def run(port, destport, ip, presentation_path, debug, logs, authtype, request_timeout, last_activity_interval, force_alive, ready_check_path, 
-        repo, repobranch, repofolder, conda_env, allow_root, notebookapp_allow_origin, forward_user_info, query_user_info, progressive, command):
+        ready_timeout, repo, repobranch, repofolder, conda_env, allow_root, notebookapp_allow_origin, forward_user_info, query_user_info, progressive, command):
 
     if debug:
         print('Setting debug')
@@ -164,7 +165,7 @@ def run(port, destport, ip, presentation_path, debug, logs, authtype, request_ti
     configure_http_client()
 
     app = make_app(destport, prefix, list(command), presentation_path, authtype, request_timeout, ready_check_path, 
-        repo, repobranch, repofolder, conda_env, debug, logs, forward_user_info, query_user_info, progressive)
+        ready_timeout, repo, repobranch, repofolder, conda_env, debug, logs, forward_user_info, query_user_info, progressive)
 
     ssl_options = get_ssl_options()
 

--- a/jhsingle_native_proxy/proxyhandlers.py
+++ b/jhsingle_native_proxy/proxyhandlers.py
@@ -732,7 +732,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
 
                 timeout = self.get_timeout()
 
-                self.log.info(cmd)
+                self.log.info(f'Running command: {cmd} with ready_timeout={timeout}')
 
                 proc = SupervisedProcess(self.name, *cmd, env=server_env, ready_func=self._http_ready_func, ready_timeout=timeout, log=self.log,
                                             stderr=subprocess.PIPE, stdout=subprocess.PIPE)

--- a/jhsingle_native_proxy/proxyhandlers.py
+++ b/jhsingle_native_proxy/proxyhandlers.py
@@ -970,7 +970,4 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             else:
                 return self._render_template(environment)
 
-        def get_timeout(self):
-            return timeout
-
     return _Proxy

--- a/jhsingle_native_proxy/proxyhandlers.py
+++ b/jhsingle_native_proxy/proxyhandlers.py
@@ -697,7 +697,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         """
         Return timeout (in s) to wait before giving up on process readiness
         """
-        return 5
+        return self.ready_timeout
 
     async def _http_ready_func(self, p):
         url = 'http://localhost:{}{}'.format(self.port, self.ready_check_path)
@@ -882,7 +882,7 @@ class SuperviseAndProxyHandler(LocalProxyHandler):
         self.origin_host = self.request.host
 
 
-def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, ready_check_path, gitwrapper, mappath):
+def _make_serverproxy_handler(name, command, environment, timeout, absolute_url, port, ready_check_path, ready_timeout, gitwrapper, mappath):
     """
     Create a SuperviseAndProxyHandler subclass with given parameters
     """
@@ -897,6 +897,7 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             self.mappath = mappath
             self.ready_check_path = ready_check_path
             self.gitwrapper = gitwrapper
+            self.ready_timeout = ready_timeout
 
         @property
         def process_args(self):
@@ -973,4 +974,3 @@ def _make_serverproxy_handler(name, command, environment, timeout, absolute_url,
             return timeout
 
     return _Proxy
-


### PR DESCRIPTION
Fixes #13 

Here's how to test the effect of this:
1. Create a flask app with the following content:
```python
from flask import Flask
from time import sleep, time

app = Flask(__name__)

started_at = time()
ready_after = 30

@app.route('/')
def hello_world():
    now = time()
    if now - started_at > ready_after:
        return 'Appliation ready!'
    else:
        # sleep for more that 1 seconds to make the _ready_check call fail: 
        # https://github.com/yuvipanda/simpervisor/blob/master/simpervisor/process.py#L196
        # Even status code 400 is considered as ready as per https://github.com/ideonate/jhsingle-native-proxy/blob/master/jhsingle_native_proxy/proxyhandlers.py#L707
        # return 'Application not yet ready! Please try later', 400
        sleep(5)
```

2. Add theses configurations to your jupyterhub
```python
c.CDSDashboardsConfig.presentation_types = ['flask']

c.VariableMixin.extra_presentation_launchers = {
    'flask': {
        'args': [
            '--ready-timeout=120',
            'flask', 'run', '{--}port={port}'
        ],
        'env': {'FLASK_APP': 'app.py'},
    }
}
```
3. Create a dashboard

Here are the logs:
[ready-timeout.log](https://github.com/ideonate/jhsingle-native-proxy/files/6318823/ready-timeout.log)


Note that this won't have any effect if the ready request takes more than 1 second because of https://github.com/yuvipanda/simpervisor/blob/master/simpervisor/process.py#L196. Example:
```python
from flask import Flask
from time import sleep

app = Flask(__name__)

@app.route('/')
def hello_world():
    sleep(5)
    return 'Appliation ready!'
```