### PR TITLE
Pin simpervisor to prevent upgrade to version 1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,4 +2,4 @@ jupyterhub>=1.0.0
 tornado>=6.0.4
 Click>=7.0
 aiohttp
-simpervisor>=0.4
+simpervisor~=0.4


### PR DESCRIPTION
This project has an issue in which the usage of simpervisor 1.0 causes 100% CPU and other nasty effects.

As per #22, we should pin this whilst the investigation proceeds.